### PR TITLE
Update README.md for machine install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,19 @@ npm i -g nonodo
 
 Download the Cartesi Machine (0.18.1-rc7) image for your OS from from [this link](https://github.com/edubart/cartesi-machine-everywhere/releases) and add the bin/ folder to your PATH:
 
+```bash
+# Replace CARTESI_MACHINE_DIR with your downloaded directory name
+export PATH="$HOME/CARTESI_MACHINE_DIR/bin:$PATH"
+
+# Example for macOS ARM64:
+export PATH="$HOME/cartesi-machine-macos-arm64/bin:$PATH"
 ```
-export PATH="/path/to/cartesi-machine/bin:$PATH"
+
+Verify the installation:
+```bash
+cartesi-machine --version
 ```
+
 3. **Set up web3.storage**
 
 Install the web3.storage CLI globally:


### PR DESCRIPTION
Documentation improvements:

* Added detailed steps to set the `PATH` environment variable for the Cartesi Machine, including an example for macOS ARM64.
* Included a command to verify the Cartesi Machine installation by checking its version.

## Before  
<img width="1041" alt="Screenshot 2024-11-18 at 3 14 33 PM" src="https://github.com/user-attachments/assets/45d6d8ce-f531-4bbf-9bef-cf606f1de0cd">

## After
<img width="1080" alt="Screenshot 2024-11-18 at 3 24 35 PM" src="https://github.com/user-attachments/assets/eadbc79b-6214-44e7-bd34-9ed68f7cf588">
