### PR TITLE
fix: devnet llama service deploy

### DIFF
--- a/docker-compose-devnet.yaml
+++ b/docker-compose-devnet.yaml
@@ -156,8 +156,9 @@ services:
       - coprocessor-network
       
   llama-server:
-    image: ghcr.io/ggerganov/llama.cpp:server
+    hostname: llama-server
     container_name: llama-server
+    image: ghcr.io/ggerganov/llama.cpp:server
     profiles: 
       - llm
     volumes:
@@ -168,4 +169,6 @@ services:
      interval: 10s
      retries: 200
      start_period: 10s
+    networks:
+      - coprocessor-network
      


### PR DESCRIPTION
The proposed changes solved this problem for the devnet environment:

```bash
2025-02-04 21:48:42 thread '<unnamed>' panicked at src/classic_request_handling.rs:392:6:
2025-02-04 21:48:42 called Result::unwrap() on an Err value: "Error querying completion request: hyper::Error(Connect, ConnectError("dns error", Custom { kind: Uncategorized, error: "failed to lookup address information: Name or service not known" }))"
2025-02-04 21:48:42 note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
```